### PR TITLE
changes master/slave to primary/secondary

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ per second, requests types, data written per second, data read per second.
 **High-level architecture design**
 
 Sketch the important components and the connections between them, but don't go into some details. 
-Usually, a scalable system includes webserver (load balancer), service (service partition), database (master/slave database cluster plug cache).
+Usually, a scalable system includes webserver (load balancer), service (service partition), database (primary/secondary database cluster plug cache).
  
 **Component design**
 


### PR DESCRIPTION
Using "master/slave" can be tasteless to offensive to some people.
Others don't care, so I guess they won't care about accepting this PR.

I know that it's better to keep the words people are used to. But even PostGreSQL tries to remove "master/slave" in favor of "primary/secondary" or "primary/replica", so people will understand anyway.

I hope this helps making tech more inclusive.
Thanks for your work and putting all these useful resources together.