### PR TITLE
fix(url)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ There are some good references for each question. The references here are slides
 
 **Design a CDN network**  
 Reference:  
-* [Globally Distributed Content Delivery](http://repository.cmu.edu/cgi/viewcontent.cgi?article=2112&context=compsci)
+* [Globally Distributed Content Delivery](https://kilthub.cmu.edu/articles/Globally_distributed_content_delivery/6605972)
 
 **Design a Google document system**  
 Reference:  


### PR DESCRIPTION
- the original urls forwards to this new domain's landing page, kilthub.cmu.edu.  Found an article with the same title, and I'm assuming it was the same article for the original url.
- updating the original url to this new url.